### PR TITLE
Mention tagName option into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ module.exports = function(environment) {
 }
 ```
 
+#### Other options
+
+An example where you can render the markdown into a tagless component:
+
+```handlebars
+{{markdown-to-html block.value tagName=''}}
+```
+
+
 ### Showdown Extensions
 
 You can load [Showdown Extensions](https://github.com/showdownjs/showdown/wiki/extensions) by specifying the


### PR DESCRIPTION
As mentioned [in this issue](https://github.com/gcollazo/ember-cli-showdown/issues/72), this seems to render the markdown without the `ember-view` div wrapper.

Didn't tried yet, just saw that opened issue that may be worth mentioning in the readme.

Maybe @sheriffderek you can confirm this worked for you ?

Of course, feel free to suggest update for the wording or code example provided here if you feel it can be better 😃 