### PR TITLE
feat: Import htmlSafe from @ember/template, not @ember/string.

### DIFF
--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-components, ember/no-classic-classes, ember/require-tagless-components, prettier/prettier, ember/no-assignment-of-untracked-properties-used-in-tracking-contexts, ember/no-get, no-prototype-builtins */
 import showdown from 'showdown';
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { get, computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import layout from '../templates/components/markdown-to-html';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4491,6 +4491,7 @@
     "node_modules/auto-changelog": {
       "version": "2.2.0",
       "resolved": "git+ssh://git@github.com/mansona/auto-changelog.git#6309eecfec6ef5aa18086074304f73964aa11f11",
+      "integrity": "sha512-szB3q/Fmr2s7SF7vugg8pBZ1U7F8oXLQmBCmG3QyYQz5QcTN1bOBdymvP1p1VaIEXfkDFOdu5agbPDWaeiyNBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
As far as I can tell, this is supposed to still just be deprecated, but it was giving a warning to the console in my 3.28 app:

```
WARNING in ./node_modules/ember-cli-showdown/components/markdown-to-html.js 42:11-19
export 'htmlSafe' (imported as 'htmlSafe') was not found in '@ember/string' (possible exports: camelize, capitalize, classify, dasherize, decamelize, getString, getStrings, setStrings, underscore, w)
```

but crashing in practice:

```
Uncaught (in promise) TypeError: (0 , _ember_string__WEBPACK_IMPORTED_MODULE_2__.htmlSafe) is not a function
    at Class.eval (markdown-to-html.js:56)
    at index.js:1937
    at untrack (validator.js:843)
    at ComputedProperty.get (index.js:1936)
    at Class.getter [as html] (index.js:1026)
    at getPossibleMandatoryProxyValue (index.js:1327)
    at _getProp (index.js:1392)
    at reference.js:214
    at reference.js:162
    at track (validator.js:827)
```


Possibly related to my using embroider on the app?