### PR TITLE
fix peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 4.0.0"
+    "ember-source": ">= 3.12.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
this just makes the declared peer match the versions of ember-source that we're testing in CI